### PR TITLE
Fix issue when deploying to Vercel

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,6 +7,11 @@ import type { LayoutLoad } from './$types';
 
 export const ssr = false;
 
+// Resolves an issue with Vercel and SvelteKit where the first request to a page fails with a 404
+// See: https://stackoverflow.com/a/78189721
+export const prerender = true;
+export const trailingSlash = 'always'; // Added this
+
 export const load: LayoutLoad = async () => {
   if (typeof window !== 'undefined') {
     initI18n();


### PR DESCRIPTION
## Overview

This PR contains the following change(s):

- Fixes an issue when deploying to Vercel by updating the SvelteKit layout configuration. Specifically, it sets `prerender = true` and `trailingSlash = 'always'` in `src/routes/+layout.ts` to resolve a problem where the first request directly to a sub-route or a page refresh on that sub-route can fail with a 404 error on Vercel deployments. This follows the workaround described in https://stackoverflow.com/a/78189721.

## Checklist

- [ ] End-to-end or unit tests (where applicable) have been added that cover this change/bug fix
- [ ] Any UI changes display properly on mobile breakpoints
- [ ] Any user-visible strings have accompanying translation tags
- [ ] Accessibility support has been added
- [ ] Analytics are being sent (where applicable)

## Issue link (optional)

_Please insert link(s) to any related issue(s)

## Reviewer notes

- Simplest way to verify is that a direct link to a sub-route or refreshing a sub-route (e.g. `/verify`) renders successfully instead of giving a 404 (which occurred in previous deployments before the fix)